### PR TITLE
Změna algoritmu generování mocking zprávy

### DIFF
--- a/src/Inkluzitron/Modules/ImagesModule.cs
+++ b/src/Inkluzitron/Modules/ImagesModule.cs
@@ -164,11 +164,8 @@ namespace Inkluzitron.Modules
         // Taken from https://github.com/Misha12/GrillBot
         #region Peepoangry
 
-        [Command("peepoangry")]
-        [Alias("angry")]
-        public async Task PeepoangryAsync(IUser member = null)
+        public async Task<string> GetPeepoangryImagePath(IUser member)
         {
-            if (member == null) member = Context.User;
             var imageName = CreateCachePath($"Peepoangry_{member.Id}_{member.AvatarId ?? member.Discriminator}.{(member.AvatarId.StartsWith("a_") ? "gif" : "png")}");
 
             if (!File.Exists(imageName))
@@ -217,6 +214,17 @@ namespace Inkluzitron.Modules
                     frame.Save(imageName, SysImgFormat.Png);
                 }
             }
+
+            return imageName;
+        }
+
+
+        [Command("peepoangry")]
+        [Alias("angry")]
+        public async Task PeepoangryAsync(IUser member = null)
+        {
+            if (member == null) member = Context.User;
+            var imageName = await GetPeepoangryImagePath(member);
 
             await ReplyFileAsync(imageName);
         }

--- a/src/Inkluzitron/Modules/MockingModule.cs
+++ b/src/Inkluzitron/Modules/MockingModule.cs
@@ -13,10 +13,13 @@ namespace Inkluzitron.Modules
         private IConfiguration Config { get; }
         private Random Random { get; }
 
+        private ImagesModule ImagesModule { get;  }
+
         public MockingModule(IConfiguration config, Random random)
         {
             Config = config;
             Random = random;
+            ImagesModule = new ImagesModule();
         }
 
         // Get maximum range value for a random number generator that decides if the char should be uppercase.
@@ -43,6 +46,15 @@ namespace Inkluzitron.Modules
                 }
 
                 hasReferencedMsg = true;
+
+                // Easter egg. If user is mocking bot, send peepoangry instead
+                if(Context.Message.ReferencedMessage.Author == Context.Guild.CurrentUser)
+                {
+                    var imageName = await ImagesModule.GetPeepoangryImagePath(Context.Message.Author);
+                    await ReplyFileAsync(imageName);
+                    return;
+                }
+
                 message = Context.Message.ReferencedMessage.ToString().ToLower();
             }
 


### PR DESCRIPTION
Předchozí algoritmus často generoval dlouhé čísti stejných písmen (Darkeriossss si na to stěžoval).

Příklad "špatně" vygenerované zprávy:
https://discord.com/channels/679717316598038623/837398240604586064/837431637444526151

Nový algoritmus, který jsem pojmenoval **Janchův® geniální algoritmus™**, by tohle měl vyřešit.

#### Prakticky to funguje tak, že
 * Když se vygeneruje uppercase znak, další znak za ním má 20% šanci, že bude taky uppercase. 
 * Pokud se ten nezmění, další za ním má už 50% šanci, že bude uppercase. 
 * Pokud ani ten ne, pak třetí nebo prostě další validní má 100% šanci že bude uppercase

*Samozřejmě to pořád respektuje zavedená pravidla, jako například pravidla změny písmen "L" a "i"*



Taky jsem tam přihodil easter egg