### PR TITLE
Implementace možnosti přesměrování příkazu

### DIFF
--- a/src/Inkluzitron/Handlers/CommandsHandler.cs
+++ b/src/Inkluzitron/Handlers/CommandsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Discord;
 using Discord.Commands;
+using Inkluzitron.Models;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Linq;
@@ -13,20 +14,19 @@ namespace Inkluzitron.Handlers
     public class CommandsHandler : IHandler
     {
         private CommandService CommandService { get; }
-
+        private IServiceProvider Provider { get; }
         private IConfiguration Configuration { get; }
 
         private Random Random { get; }
 
-        public CommandsHandler(Random random, CommandService commandService, IConfiguration configuration)
+        public CommandsHandler(Random random, CommandService commandService, IConfiguration configuration, IServiceProvider provider)
         {
             CommandService = commandService;
+            Configuration = configuration;
+            Random = random;
+            Provider = provider;
 
             CommandService.CommandExecuted += CommandExecutedAsync;
-
-            Configuration = configuration;
-
-            Random = random;
         }
 
         private string GetCommandFormat(CommandInfo command, ParameterInfo highlightArg = null)
@@ -47,12 +47,19 @@ namespace Inkluzitron.Handlers
 
         private async Task CommandExecutedAsync(Optional<CommandInfo> command, ICommandContext context, IResult result)
         {
+            // Null is success, because some modules returns null after success and library always returns ExecuteResult.
+            if (result == null) result = ExecuteResult.FromSuccess();
+
             if (!result.IsSuccess && result.Error != null)
             {
                 string reply = "";
 
                 switch (result.Error.Value)
                 {
+                    case CommandError.Unsuccessful when result is CommandRedirectResult crr && !string.IsNullOrEmpty(crr.NewCommand):
+                        await CommandService.ExecuteAsync(context, crr.NewCommand, Provider);
+                        break;
+
                     case CommandError.UnmetPrecondition:
                     case CommandError.Unsuccessful:
                         reply = result.ErrorReason;

--- a/src/Inkluzitron/Models/CommandRedirectResult.cs
+++ b/src/Inkluzitron/Models/CommandRedirectResult.cs
@@ -1,0 +1,18 @@
+﻿using Discord.Commands;
+
+namespace Inkluzitron.Models
+{
+    public class CommandRedirectResult : RuntimeResult
+    {
+        public string NewCommand { get; set; }
+
+        public CommandRedirectResult(string newCommand) : base(CommandError.Unsuccessful, null)
+        {
+            NewCommand = newCommand;
+        }
+
+        public CommandRedirectResult(CommandError? error, string reason) : base(error, reason)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Implementace nového příkazu pro přesměrování na nový příkaz. Postup:

1) Příkaz, který bude nově využívat přesměrování musí vracet `Task<RuntimeResult>`.
2) Pokud se bude vracet konec provádění, tak vrátit `null`. Pokud se bude přesměrovávat na nový command, tak vrátit `new CommandRedirectResult("{newCommand}")`. Hodnota `{newCommand}` bude stejná, jako by se zadával příkaz na discordu, jen **bez prefixu**.

*Jedná se o volitelnou implementaci. Pro ostatní příkazy se nic nemění.*