### PR TITLE
Vylepšení modulu testu. Především zadávání nového testu pouze odkazem

### DIFF
--- a/src/Inkluzitron/Data/BotDatabaseContext.cs
+++ b/src/Inkluzitron/Data/BotDatabaseContext.cs
@@ -22,7 +22,9 @@ namespace Inkluzitron.Data
         {
             modelBuilder.Entity<QuizResult>().HasKey(r => r.ResultId);
             modelBuilder.Entity<QuizResult>().HasDiscriminator<string>("Discriminator");
-            modelBuilder.Entity<QuizResult>().HasMany(r => r.Items);
+            modelBuilder.Entity<QuizResult>().HasMany(r => r.Items)
+                .WithOne(i => i.Parent)
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<QuizItem>().HasKey(i => i.ItemId);
             modelBuilder.Entity<QuizItem>().HasOne(i => i.Parent);

--- a/src/Inkluzitron/Data/BotDatabaseContext.cs
+++ b/src/Inkluzitron/Data/BotDatabaseContext.cs
@@ -26,6 +26,8 @@ namespace Inkluzitron.Data
                 .WithOne(i => i.Parent)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            modelBuilder.Entity<BdsmTestOrgQuizResult>().HasIndex(r => r.Link).IsUnique();
+
             modelBuilder.Entity<QuizItem>().HasKey(i => i.ItemId);
             modelBuilder.Entity<QuizItem>().HasOne(i => i.Parent);
             modelBuilder.Entity<QuizItem>().HasDiscriminator<string>("Discriminator");

--- a/src/Inkluzitron/Inkluzitron.csproj
+++ b/src/Inkluzitron/Inkluzitron.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />

--- a/src/Inkluzitron/Migrations/20210516193854_QuizResultDeleteContraint.Designer.cs
+++ b/src/Inkluzitron/Migrations/20210516193854_QuizResultDeleteContraint.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Inkluzitron.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Inkluzitron.Migrations
 {
     [DbContext(typeof(BotDatabaseContext))]
-    partial class BotDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210516193854_QuizResultDeleteContraint")]
+    partial class QuizResultDeleteContraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Inkluzitron/Migrations/20210516193854_QuizResultDeleteContraint.cs
+++ b/src/Inkluzitron/Migrations/20210516193854_QuizResultDeleteContraint.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Inkluzitron.Migrations
+{
+    public partial class QuizResultDeleteContraint : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_QuizItems_QuizResults_ParentResultId",
+                table: "QuizItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QuizItems_QuizResults_ParentResultId",
+                table: "QuizItems",
+                column: "ParentResultId",
+                principalTable: "QuizResults",
+                principalColumn: "ResultId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_QuizItems_QuizResults_ParentResultId",
+                table: "QuizItems");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QuizItems_QuizResults_ParentResultId",
+                table: "QuizItems",
+                column: "ParentResultId",
+                principalTable: "QuizResults",
+                principalColumn: "ResultId",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/Inkluzitron/Migrations/20210516212903_BdsmTestOrgQuizResultUniqueLink.Designer.cs
+++ b/src/Inkluzitron/Migrations/20210516212903_BdsmTestOrgQuizResultUniqueLink.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Inkluzitron.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Inkluzitron.Migrations
 {
     [DbContext(typeof(BotDatabaseContext))]
-    partial class BotDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210516212903_BdsmTestOrgQuizResultUniqueLink")]
+    partial class BdsmTestOrgQuizResultUniqueLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Inkluzitron/Migrations/20210516212903_BdsmTestOrgQuizResultUniqueLink.cs
+++ b/src/Inkluzitron/Migrations/20210516212903_BdsmTestOrgQuizResultUniqueLink.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Inkluzitron.Migrations
+{
+    public partial class BdsmTestOrgQuizResultUniqueLink : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizResults_Link",
+                table: "QuizResults",
+                column: "Link",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_QuizResults_Link",
+                table: "QuizResults");
+        }
+    }
+}

--- a/src/Inkluzitron/Models/BdsmTestOrgApi/Result.cs
+++ b/src/Inkluzitron/Models/BdsmTestOrgApi/Result.cs
@@ -7,8 +7,11 @@ namespace Inkluzitron.Models.BdsmTestOrgApi
     public class Result
     {
         [JsonConverter(typeof(Newtonsoft.Json.Converters.IsoDateTimeConverter))]
-        [JsonProperty("date")]
+        [JsonProperty("date", Required = Required.Always)]
         public DateTime Date { get; set; }
+
+        [JsonProperty("scores", Required = Required.Always)]
+        public List<ResultItem> Traits { get; set; }
 
         [JsonProperty("version")]
         public string Version { get; set; }
@@ -19,7 +22,5 @@ namespace Inkluzitron.Models.BdsmTestOrgApi
         [JsonProperty("auth")]
         public bool RegisteredUser { get; set; }
 
-        [JsonProperty("scores")]
-        public List<ResultItem> Traits { get; set; }
     }
 }

--- a/src/Inkluzitron/Models/BdsmTestOrgApi/Result.cs
+++ b/src/Inkluzitron/Models/BdsmTestOrgApi/Result.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Inkluzitron.Models.BdsmTestOrgApi
+{
+    public class Result
+    {
+        [JsonConverter(typeof(Newtonsoft.Json.Converters.IsoDateTimeConverter))]
+        [JsonProperty("date")]
+        public DateTime Date { get; set; }
+
+        [JsonProperty("version")]
+        public string Version { get; set; }
+
+        [JsonProperty("gender")]
+        public string Gender { get; set; }
+
+        [JsonProperty("auth")]
+        public bool RegisteredUser { get; set; }
+
+        [JsonProperty("scores")]
+        public List<ResultItem> Traits { get; set; }
+    }
+}

--- a/src/Inkluzitron/Models/BdsmTestOrgApi/ResultItem.cs
+++ b/src/Inkluzitron/Models/BdsmTestOrgApi/ResultItem.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Inkluzitron.Models.BdsmTestOrgApi
+{
+    public class ResultItem
+    {
+
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("score")]
+        public int Score { get; set; }
+    }
+}

--- a/src/Inkluzitron/Models/BdsmTestOrgApi/ResultItem.cs
+++ b/src/Inkluzitron/Models/BdsmTestOrgApi/ResultItem.cs
@@ -5,13 +5,20 @@ namespace Inkluzitron.Models.BdsmTestOrgApi
     public class ResultItem
     {
 
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public int Id { get; set; }
+
+        [JsonProperty("score", Required = Required.Always)]
+        public int Score { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("score")]
-        public int Score { get; set; }
+        [JsonProperty("description")]
+        public string Description{ get; set; }
+
+        [JsonProperty("pairdesc")]
+        public string PairDescription { get; set; }
+
     }
 }

--- a/src/Inkluzitron/Models/Settings/BdsmTestOrgApiKey.cs
+++ b/src/Inkluzitron/Models/Settings/BdsmTestOrgApiKey.cs
@@ -1,0 +1,12 @@
+﻿using Inkluzitron.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace Inkluzitron.Models.Settings
+{
+    public class BdsmTestOrgApiKey
+    {
+        public string Uid { get; set; }
+        public string Salt { get; set; }
+        public string AuthSig { get; set; }
+    }
+}

--- a/src/Inkluzitron/Models/Settings/BdsmTestOrgSettings.cs
+++ b/src/Inkluzitron/Models/Settings/BdsmTestOrgSettings.cs
@@ -20,7 +20,7 @@ namespace Inkluzitron.Models.Settings
         public string NoTraitsToReportMessage { get; }
         public string InvalidVerboseModeUsage { get; }
         public string BadFilterQueryMessage { get; }
-        public ReadOnlyCollection<BdsmTestOrgTrait> Traits { get; }
+        public IReadOnlyCollection<BdsmTestOrgTrait> Traits { get; }
         public string TestLinkUrl { get; }
 
         public BdsmTestOrgSettings(IConfiguration config)
@@ -41,7 +41,7 @@ namespace Inkluzitron.Models.Settings
             NoTraitsToReportMessage = cfg.GetRequired<string>(nameof(NoTraitsToReportMessage));
             BadFilterQueryMessage = cfg.GetRequired<string>(nameof(BadFilterQueryMessage));
             TestLinkUrl = cfg.GetRequired<string>(nameof(TestLinkUrl));
-            Traits = cfg.GetRequired<List<BdsmTestOrgTrait>>(nameof(Traits)).AsReadOnly();
+            Traits = cfg.GetRequired<IReadOnlyCollection<BdsmTestOrgTrait>>(nameof(Traits));
         }
     }
 }

--- a/src/Inkluzitron/Models/Settings/BdsmTestOrgSettings.cs
+++ b/src/Inkluzitron/Models/Settings/BdsmTestOrgSettings.cs
@@ -1,12 +1,13 @@
 ﻿using Inkluzitron.Extensions;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.ObjectModel;
 
 namespace Inkluzitron.Models.Settings
 {
     public class BdsmTestOrgSettings
     {
+        public BdsmTestOrgApiKey ApiKey { get; }
         public string NoResultsOnRecordMessage { get; }
         public string InvalidFormatMessage { get; }
         public string LinkAlreadyPresentMessage { get; }
@@ -19,7 +20,7 @@ namespace Inkluzitron.Models.Settings
         public string NoTraitsToReportMessage { get; }
         public string InvalidVerboseModeUsage { get; }
         public string BadFilterQueryMessage { get; }
-        public IReadOnlySet<string> TraitList { get; }
+        public ReadOnlyCollection<BdsmTestOrgTrait> Traits { get; }
         public string TestLinkUrl { get; }
 
         public BdsmTestOrgSettings(IConfiguration config)
@@ -27,6 +28,7 @@ namespace Inkluzitron.Models.Settings
             var cfg = config.GetSection("BdsmTestOrgQuizModule");
             cfg.AssertExists();
 
+            ApiKey = cfg.GetRequired<BdsmTestOrgApiKey>(nameof(ApiKey));
             NoResultsOnRecordMessage = cfg.GetRequired<string>(nameof(NoResultsOnRecordMessage));
             InvalidFormatMessage = cfg.GetRequired<string>(nameof(InvalidFormatMessage));
             LinkAlreadyPresentMessage = cfg.GetRequired<string>(nameof(LinkAlreadyPresentMessage));
@@ -39,10 +41,7 @@ namespace Inkluzitron.Models.Settings
             NoTraitsToReportMessage = cfg.GetRequired<string>(nameof(NoTraitsToReportMessage));
             BadFilterQueryMessage = cfg.GetRequired<string>(nameof(BadFilterQueryMessage));
             TestLinkUrl = cfg.GetRequired<string>(nameof(TestLinkUrl));
-
-            var traitsSection = cfg.GetSection("Traits");
-            traitsSection.AssertExists();
-            TraitList = new HashSet<string>(traitsSection.GetChildren().Select(c => c.Value));
+            Traits = cfg.GetRequired<List<BdsmTestOrgTrait>>(nameof(Traits)).AsReadOnly();
         }
     }
 }

--- a/src/Inkluzitron/Models/Settings/BdsmTestOrgTrait.cs
+++ b/src/Inkluzitron/Models/Settings/BdsmTestOrgTrait.cs
@@ -1,0 +1,8 @@
+﻿namespace Inkluzitron.Models.Settings
+{
+    public class BdsmTestOrgTrait
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/Inkluzitron/Modules/BdsmTestOrg/BdsmModule.cs
+++ b/src/Inkluzitron/Modules/BdsmTestOrg/BdsmModule.cs
@@ -121,7 +121,7 @@ namespace Inkluzitron.Modules.BdsmTestOrg
                 var resultsGot = resultsDict.TryGetValue(trait, out var items) && items.Count > 0;
                 if (!resultsGot) continue;
 
-                resultsLine = string.Join(", ", items.Select(i => $"<@{i.Parent.SubmittedById}> ({i.Value:P0})"));
+                resultsLine = string.Join(", ", items.Select(i => $"**`{i.Parent.SubmittedByName}`** ({i.Value:P0})"));
 
                 results.AppendFormat("**{0}**: ", trait);
                 results.AppendLine(resultsLine);

--- a/src/Inkluzitron/Modules/BdsmTestOrg/BdsmModule.cs
+++ b/src/Inkluzitron/Modules/BdsmTestOrg/BdsmModule.cs
@@ -4,12 +4,10 @@ using Inkluzitron.Data;
 using Inkluzitron.Data.Entities;
 using Inkluzitron.Extensions;
 using Inkluzitron.Models.Settings;
-using Inkluzitron.Services;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -34,15 +32,17 @@ namespace Inkluzitron.Modules.BdsmTestOrg
         private ReactionSettings ReactionSettings { get; }
         private BdsmTestOrgSettings Settings { get; }
         private GraphPaintingService GraphPainter { get; }
-        private HttpClient HttpClient { get; }
+        private IHttpClientFactory HttpClientFactory { get; }
 
-        public BdsmModule(DatabaseFactory databaseFactory, ReactionSettings reactionSettings, BdsmTestOrgSettings bdsmTestOrgSettings, GraphPaintingService graphPainter)
+        public BdsmModule(DatabaseFactory databaseFactory,
+            ReactionSettings reactionSettings, BdsmTestOrgSettings bdsmTestOrgSettings,
+            GraphPaintingService graphPainter, IHttpClientFactory factory)
         {
             DatabaseFactory = databaseFactory;
             ReactionSettings = reactionSettings;
             Settings = bdsmTestOrgSettings;
             GraphPainter = graphPainter;
-            HttpClient = new();
+            HttpClientFactory = factory;
         }
 
         protected override void BeforeExecute(CommandInfo command)
@@ -251,9 +251,9 @@ namespace Inkluzitron.Modules.BdsmTestOrg
                 { "rauth[rid]", testid }
             };
 
-            var content = new FormUrlEncodedContent(requestData);
-
-            var response = await HttpClient.PostAsync("https://bdsmtest.org/ajax/getresult", content);
+            var response = await HttpClientFactory.CreateClient().PostAsync(
+                "https://bdsmtest.org/ajax/getresult",
+                new FormUrlEncodedContent(requestData));
 
             var responseData = await response.Content.ReadAsStringAsync();
             var testResult = JsonConvert.DeserializeObject<Result>(responseData);

--- a/src/Inkluzitron/Modules/BdsmTestOrg/BdsmModule.cs
+++ b/src/Inkluzitron/Modules/BdsmTestOrg/BdsmModule.cs
@@ -270,10 +270,14 @@ namespace Inkluzitron.Modules.BdsmTestOrg
             {
                 if (!Settings.Traits.Any(t => t.Id == trait.Id)) continue;
 
+                var percentage = trait.Score / 100.0;
+                if (percentage > 1) percentage = 1;
+                else if (percentage < 0) percentage = 0;
+
                 testResultDb.Items.Add(new QuizDoubleItem
                 {
                     Key = trait.Name,
-                    Value = trait.Score / 100.0
+                    Value = percentage
                 });
             }
 

--- a/src/Inkluzitron/Modules/RolePicker/RolePickerModule.cs
+++ b/src/Inkluzitron/Modules/RolePicker/RolePickerModule.cs
@@ -17,7 +17,8 @@ namespace Inkluzitron.Modules
 {
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [Name("Uživatelsky volitelné role")]
-    [Group("rolepicker")]
+    [Group("rolemenu")]
+    [Alias("rolepicker")]
     public class RolePickerModule : ModuleBase
     {
         private DiscordSocketClient Client { get; }
@@ -83,12 +84,12 @@ namespace Inkluzitron.Modules
             var replyBuilder = new EmbedBuilder();
             replyBuilder.WithTitle("Seznam zpráv pro výběr rolí");
 
-            var messages = DbContext.UserRoleMessage.AsEnumerable()
-                .OrderBy(m => new { m.GuildId, m.ChannelId });
+            var messages = DbContext.UserRoleMessage.AsAsyncEnumerable()
+                .OrderBy(m => m.GuildId).ThenBy(m => m.ChannelId);
 
             SocketTextChannel channel = null;
             StringBuilder channelBuilder = null;
-            foreach (var data in messages)
+            await foreach (var data in messages)
             {
                 if (channel == null || channel.Id != data.ChannelId || channel.Guild.Id != data.GuildId)
                 {

--- a/src/Inkluzitron/Program.cs
+++ b/src/Inkluzitron/Program.cs
@@ -70,7 +70,8 @@ namespace Inkluzitron
                 .AddSingleton<ReactionsModule>()
                 .AddSingleton<ProfilePictureService>()
                 .AddSingleton<FontService>()
-                .AddSingleton<GraphPaintingService>();
+                .AddSingleton<GraphPaintingService>()
+                .AddHttpClient();
 
             services.AddLogging(config =>
             {

--- a/src/Inkluzitron/appsettings.json
+++ b/src/Inkluzitron/appsettings.json
@@ -19,9 +19,14 @@
         "BdsmTestResultAdded": "<:pepeballgag:834482900715307080>"
     },
     "BdsmTestOrgQuizModule": {
+        "ApiKey": {
+            "Uid": 0,
+            "Salt": "",
+            "AuthSig": "814a69afc15258000678f00526b0c107ac271b5ea997beb4f7c1e81c861c972b"
+        },
         "NoResultsOnRecordMessage": "V databázi nemáš žádný výsledek k zobrazení <:sadge:834159415815962705> \n Utíkej na https://bdsmtest.org/ a potom textový výsledek textu zkopíruj do podpříkazu *add*.",
         "LinkAlreadyPresentMessage": "Výsledek s tímto odkazem už má v databázi někdo jiný <:smrckabat:834164716657704990>",
-        "InvalidFormatMessage": "Tak to mi nevychádza! <:sadcat:834180115508232202> Zkopíruj prosím celý textový výsledek, včetně hlavičky a odkazu na konci.",
+        "InvalidFormatMessage": "Tak to mi nevychádza! <:sadcat:834180115508232202>\nDej mi odkaz na výsledek (měl by vypadat nějak takhle: https://bdsmtest.org/r/A1B2C3D4).",
         "InvalidTraitMessage": "Některý z výsledků má neplatnou kategorii <:smrckabat:834164716657704990>",
         "InvalidPercentageMessage": "Některý z výsledků má neplatnou procentuální hodnotu <:smrckabat:834164716657704990>",
         "InvalidTraitCountMessage": "Výsledky testu neobsahují všechny očekávané hodnoty <:smrckabat:834164716657704990>",
@@ -32,31 +37,106 @@
         "TraitReportingThreshold": 0.5,
         "NoTraitsToReportMessage": "Ve výsledcích testu není k vidění nic spicy. Vanilla it is :slight_smile:",
         "Traits": [
-            "Switch",
-            "Voyeur",
-            "Rope bunny",
-            "Brat",
-            "Dominant",
-            "Vanilla",
-            "Submissive",
-            "Brat tamer",
-            "Rigger",
-            "Non-monogamist",
-            "Experimentalist",
-            "Exhibitionist",
-            "Degradee",
-            "Masochist",
-            "Owner",
-            "Master/Mistress",
-            "Sadist",
-            "Degrader",
-            "Primal (Hunter)",
-            "Pet",
-            "Daddy/Mommy",
-            "Slave",
-            "Primal (Prey)",
-            "Boy/Girl",
-            "Ageplayer"
+            {
+                "id": 1,
+                "name": "Ageplayer"
+            },
+            {
+                "id": 3,
+                "name": "Brat"
+            },
+            {
+                "id": 4,
+                "name": "Brat tamer"
+            },
+            {
+                "id": 5,
+                "name": "Daddy/Mommy"
+            },
+            {
+                "id": 6,
+                "name": "Degrader"
+            },
+            {
+                "id": 7,
+                "name": "Dominant"
+            },
+            {
+                "id": 8,
+                "name": "Degradee"
+            },
+            {
+                "id": 10,
+                "name": "Boy/Girl"
+            },
+            {
+                "id": 11,
+                "name": "Masochist"
+            },
+            {
+                "id": 12,
+                "name": "Master/Mistress"
+            },
+            {
+                "id": 13,
+                "name": "Non-monogamist"
+            },
+            {
+                "id": 14,
+                "name": "Owner"
+            },
+            {
+                "id": 17,
+                "name": "Primal (Hunter)"
+            },
+            {
+                "id": 18,
+                "name": "Pet"
+            },
+            {
+                "id": 19,
+                "name": "Primal (Prey)"
+            },
+            {
+                "id": 20,
+                "name": "Rigger"
+            },
+            {
+                "id": 21,
+                "name": "Rope bunny"
+            },
+            {
+                "id": 22,
+                "name": "Sadist"
+            },
+            {
+                "id": 23,
+                "name": "Slave"
+            },
+            {
+                "id": 24,
+                "name": "Submissive"
+            },
+            {
+                "id": 25,
+                "name": "Switch"
+            },
+            {
+                "id": 26,
+                "name": "Vanilla"
+            },
+            {
+                "id": 27,
+                "name": "Voyeur"
+            },
+            {
+                "id": 28,
+                "name": "Exhibitionist"
+            },
+            {
+                "id": 29,
+                "name": "Experimentalist"
+            }
         ]
     },
     "HolidayApi": "https://svatky.adresa.info/json",


### PR DESCRIPTION
**Ve zkratce:**
* Jednodušší přidání testu (jen odkazem)
* Oprava mazání existujících testů (bylo tam třeba přidat cascade delete)
* `$bdsm list` (dříve `$bdsm gdo`) nepoužívá tagy k zobrazení uživatelů
* Nesouvisí s bdsmtestem - přidán alias `$rolemenu` na `$rolepicker`
* Upraveny příkazy bdsm testu. Viz help screenshot: 
  ![image](https://user-images.githubusercontent.com/7803688/118412042-1a739a00-b698-11eb-849c-4d2e81eb9036.png)
  * `$bdsm list` má pořád alias `$bdsm gdo` pro zpětnou kompatibilitu
  * přidán alias `$bdsm graph` na `$bdsm stats`.


***Btw:** Chtělo by to přidat zobrazení aliasů do `$help`*